### PR TITLE
Added Polyglot support

### DIFF
--- a/npcchatter.js
+++ b/npcchatter.js
@@ -8,11 +8,11 @@ class NpcChatter {
     return tables;
   }
 
-  randomGlobalChatterEvery(milliseconds) {
-    NpcChatter.timer = window.setInterval(() => { game.npcChatter.globalChatter(); }, milliseconds);
+  randomGlobalChatterEvery(milliseconds, options={}) {
+    NpcChatter.timer = window.setInterval(() => { game.npcChatter.globalChatter(options); }, milliseconds);
   }
 
-  async globalChatter() {
+  async globalChatter(options={}) {
     const tables = this.getChatterTables();
 
     const userCharacterActorIds = game.users.contents.filter(x => x.character).map(x => x.character.id);
@@ -36,7 +36,8 @@ class NpcChatter {
       tokenId: token.data._id,
       msg: result
     });
-    await canvas.hud.bubbles.say(token.data, result, false);
+    const emote = Object.keys(options).length ? {emote: options} : false;
+    await canvas.hud.bubbles.say(token.data, result, emote);
   }
 
   async tokenChatter(token, options={}) {
@@ -54,11 +55,11 @@ class NpcChatter {
       tokenId: token.data._id,
       msg: result
     });
-    let emote = Object.keys(options).length ? {emote: options} : false;
+    const emote = Object.keys(options).length ? {emote: options} : false;
     await canvas.hud.bubbles.say(token.data, result, emote);
   }
 
-  async selectedChatter() {
+  async selectedChatter(options={}) {
     const tables = this.getChatterTables();
 
     const npcTokens = canvas.tokens.controlled;
@@ -80,7 +81,8 @@ class NpcChatter {
       tokenId: token.id,
       msg: result
     });
-    await canvas.hud.bubbles.say(token, result, false);
+    const emote = Object.keys(options).length ? {emote: options} : false;
+    await canvas.hud.bubbles.say(token, result, emote);
   }
   
   async turnOffGlobalTimerChatter() {

--- a/npcchatter.js
+++ b/npcchatter.js
@@ -39,7 +39,7 @@ class NpcChatter {
     await canvas.hud.bubbles.say(token.data, result, false);
   }
 
-  async tokenChatter(token) {
+  async tokenChatter(token, options={}) {
     const tables = this.getChatterTables();
 
     const eligableTables = tables.filter(x => token.name.toLowerCase().includes(x.name.toLowerCase().replace("chatter", "").trim()));
@@ -54,7 +54,8 @@ class NpcChatter {
       tokenId: token.data._id,
       msg: result
     });
-    await canvas.hud.bubbles.say(token.data, result, false);
+    let emote = Object.keys(options).length ? {emote: options} : false;
+    await canvas.hud.bubbles.say(token.data, result, emote);
   }
 
   async selectedChatter() {


### PR DESCRIPTION
Hey, I'm the dev of Polyglot and it doesn't work with NPC Chatter. Here's a little change to make them work together:

I'm exploiting the emote parameter being an unused object to pass info through it. If nothing is being passed, it'll default to false, as it always did. This could be useful for other modules that change chat bubbles too.

Why Polyglot didn't work before:
Polyglot compares the Bubble's content with the last 10 messages sent, but `canvas.hud.bubbles.say()` doesn't produce a Chat Message. So I'll check if there's an `emote.language` value first for this case.